### PR TITLE
generator.py crunchbang specify python2

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # Generater code from opcodes from http://pastraiser.com/cpu/gameboy/gameboy_opcodes.html
 
 import re


### PR DESCRIPTION
Runs on systems where python3 is the default python.
