### PR TITLE
Execute python files using python 2 on all distros

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # Generater code from opcodes from http://pastraiser.com/cpu/gameboy/gameboy_opcodes.html
 
 import re

--- a/test/mrdo-asm.py
+++ b/test/mrdo-asm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 # This is unfinished script to convert Mr.Do! source code to format acceptable by rgbasm
 


### PR DESCRIPTION
On distros that default to python 3, the shebangs in src/generator.py
and test/mrdo-asm.py will cause the files to be executed with Python 3.
This version mismatch causes the scripts to crash. In the case of generator.py
no opcodes are generated and gb-disasm subsequently provides incorrect output.

Fix this by using /usr/bin/env to find the system's python2 binary
